### PR TITLE
Add game, gui, and window focus functions

### DIFF
--- a/pymhf/core/utils.py
+++ b/pymhf/core/utils.py
@@ -28,15 +28,7 @@ def is_window_active(windowName):
 def activate_window(windowName):
     if is_window_launched(windowName):
         get_window(windowName).activate()
-
-
-def set_nms_window_focus():
-    activate_window("No Man's Sky")
-
-
-def set_gui_window_focus():
-    activate_window("pyMHF")
-
+        
 
 def safe_assign_enum(enum, index: int):
     """ Safely try and get the enum with the associated integer value.

--- a/pymhf/core/utils.py
+++ b/pymhf/core/utils.py
@@ -2,7 +2,6 @@ from ctypes import windll, create_unicode_buffer, byref, c_ulong
 from configparser import ConfigParser
 from typing import Optional
 import pywinctl as pwc
-from pywinctl import Window
 
 #Window class methods and properties detailed at https://github.com/Kalmat/PyWinCtl?tab=readme-ov-file
 
@@ -28,7 +27,7 @@ def is_window_active(windowName):
 def activate_window(windowName):
     if is_window_launched(windowName):
         get_window(windowName).activate()
-        
+
 
 def safe_assign_enum(enum, index: int):
     """ Safely try and get the enum with the associated integer value.

--- a/pymhf/core/utils.py
+++ b/pymhf/core/utils.py
@@ -1,6 +1,9 @@
 from ctypes import windll, create_unicode_buffer, byref, c_ulong
 from configparser import ConfigParser
 from typing import Optional
+import pywinctl as pwc
+
+#Window class methods and properties detailed at https://github.com/Kalmat/PyWinCtl?tab=readme-ov-file
 
 # from pymhf import _internal
 
@@ -8,6 +11,30 @@ from typing import Optional
 # def dump_resource(res, fname):
 #     with open(op.join(_internal.CWD, fname), "w") as f:
 #         f.write(json.dumps(res, indent=2))
+
+def is_window_launched(windowName):
+    return pwc.getWindowsWithTitle(windowName) is not None
+
+
+def get_window(windowName):
+    return pwc.getWindowsWithTitle(windowName)[0]
+
+
+def is_window_active(windowName):
+    return windowName == pwc.getActiveWindowTitle()
+
+
+def activate_window(windowName):
+    if is_window_launched(windowName):
+        get_window(windowName).activate()
+
+
+def set_nms_window_focus():
+    activate_window("No Man's Sky")
+
+
+def set_gui_window_focus():
+    activate_window("pyMHF")
 
 
 def safe_assign_enum(enum, index: int):

--- a/pymhf/core/utils.py
+++ b/pymhf/core/utils.py
@@ -2,6 +2,7 @@ from ctypes import windll, create_unicode_buffer, byref, c_ulong
 from configparser import ConfigParser
 from typing import Optional
 import pywinctl as pwc
+from pywinctl import Window
 
 #Window class methods and properties detailed at https://github.com/Kalmat/PyWinCtl?tab=readme-ov-file
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "pywin32",
   "dearpygui~=1.11.0",
   "questionary",
+  "pywinctl",
 ]
 version = "0.1.4"
 


### PR DESCRIPTION
**This pull requests makes the following changes:**

- *Fixes issue #6
- *Add's pywinctl to dependencies in .toml
- *Add's window management functions in .core.utils
- *Game window can be focused with `set_nms_window_focus()`
- *Gui window can be focused with `set_gui_window_focus()`
- *Additional functions enable users to manage other windows
- *All functionality available through `import pymhf.core.utils`

