### PR TITLE
gh-4: Implement GUI reloading when widgets change in mods

### DIFF
--- a/pymhf/gui/gui.py
+++ b/pymhf/gui/gui.py
@@ -1,5 +1,7 @@
+from enum import Enum
 import traceback
-from typing import TypedDict
+import logging
+from typing import TypedDict, Union, Optional
 # import win32gui
 # import win32con
 
@@ -16,9 +18,18 @@ SETTINGS_NAME = "_pymhf_gui_settings"
 # - Add support for mod states
 
 
-class ModWidgets(TypedDict):
-    buttons: list
-    variables: list
+logger = logging.getLogger("GUILogger")
+
+
+class WidgetType(Enum):
+    BUTTON = 0
+    VARIABLE = 1
+    TEXT = 2
+
+
+class Widgets(TypedDict):
+    buttons: dict[str, Union[int, str]]
+    variables: dict[str, list[tuple[Union[int, str], WidgetType]]]
 
 
 class GUI:
@@ -34,13 +45,14 @@ class GUI:
         )
         dpg.setup_dearpygui()
         dpg.set_global_font_scale(self.scale)
-        self.tracking_variables = []
-        self.tabs = []
+        self.tracking_variables: dict[str, list[tuple[str, Mod, str, bool]]] = {}
+        self.tabs: dict[int, str] = {}
         self._shown = True
         self._handle = None
+        self._current_tab: Optional[str] = None
         self.mod_manager = mod_manager
 
-        self.mod_widgets: dict[str, ModWidgets] = {}
+        self.widgets: dict[str, Widgets] = {}
 
         # Keep track of the viewport dimensions and position.
         # NOTE: These are ONLY updated when the viewport is minimised by the `hide_window` method.
@@ -82,8 +94,9 @@ class GUI:
         with dpg.value_registry():
             dpg.add_bool_value(tag="is_debug", default_value=False)
             dpg.add_bool_value(tag="show_gui", default_value=True)
-        with dpg.tab(label="Settings", tag=SETTINGS_NAME, parent="tabbar"):
-            self.tabs.append("Settings")
+        tab = dpg.add_tab(label="Settings", tag=SETTINGS_NAME, parent="tabbar")
+        tab_alias = dpg.get_alias_id(tab)
+        self.tabs[tab_alias] = SETTINGS_NAME
 
         # Toggle for debug mode
         with dpg.group(horizontal=True, parent=SETTINGS_NAME):
@@ -100,6 +113,73 @@ class GUI:
                 callback=self.toggle_show_gui,
             )
 
+    def reload_tab(self, cls: Mod):
+        """ Reload the tab for the specific mod. """
+        name = cls.__class__.__name__
+        cls._gui = self
+        widgets = self.widgets.get(name, {})
+
+        self.reload_buttons(cls, widgets)
+        self.reload_variables(cls, widgets)
+
+    def reload_buttons(self, cls: Mod, widgets: Widgets):
+        """ Reload all the buttons. Any new buttons will be added, any old ones will be removed, and any that
+        remain will be reconfigured to point to the new bound method with any modified parameters (such as
+        button label.)
+        """
+        button_widgets = widgets["buttons"]
+
+        existing_button_names = set([b for b in button_widgets.keys()])
+        mod_button_names = set([b for b in cls._gui_buttons.keys()])
+
+        new_buttons = mod_button_names - existing_button_names
+        for button_name in new_buttons:
+            self.add_button(cls._gui_buttons[button_name])
+
+        remaining_buttons = existing_button_names & mod_button_names
+        for button_name in remaining_buttons:
+            _button = cls._gui_buttons[button_name]
+            dpg.configure_item(button_widgets[button_name], label=_button._button_text, callback=_button)
+
+        removed_buttons = existing_button_names - mod_button_names
+        for button_name in removed_buttons:
+            dpg.delete_item(button_widgets[button_name])
+
+    def reload_variables(self, cls: Mod, widgets: Widgets):
+        """ Reload all variables associated with a mod.
+        Note that this will not work for changing an existing variables' type.
+        To do this, remove (comment out) the property, reload the mod, and then uncomment, change the type and
+        reload again to have it add it back.
+        """
+        variable_widgets = widgets["variables"]
+
+        existing_variable_names = set([v for v in variable_widgets.keys()])
+        mod_variable_names = set([v for v in cls._gui_variables.keys()])
+
+        new_variables = mod_variable_names - existing_variable_names
+        for variable_name in new_variables:
+            self.add_variable(cls, variable_name, cls._gui_variables[variable_name])
+
+        remaining_variables = existing_variable_names & mod_variable_names
+        for variable_name in remaining_variables:
+            # Loop over the text and variable ids so we may update them.
+            for var_id, var_type in variable_widgets[variable_name]:
+                if var_type == WidgetType.TEXT:
+                    dpg.set_value(var_id, cls._gui_variables[variable_name]._label_text)
+                else:
+                    dpg.configure_item(var_id, user_data=(cls, variable_name))
+
+        removed_variables = existing_variable_names - mod_variable_names
+        for variable_name in removed_variables:
+            # Remove the variable itself which dpg uses to store the value, as well as all widgets (text and
+            # inputs) associated with it.
+            name = cls.__class__.__name__
+            tag = f"{name}.{variable_name}"
+            dpg.delete_item(tag)
+            for var_id, _ in variable_widgets[variable_name]:
+                dpg.delete_item(var_id)
+
+
     def add_tab(self, cls: Mod):
         """ Add the mod as a new tab in the GUI. """
         # Check to see if the `no_gui` decorator has been applied to the class.
@@ -110,21 +190,30 @@ class GUI:
         name = cls.__class__.__name__
         cls._gui = self
 
-        with dpg.tab(label=name, tag=name, parent="tabbar"):
-            dpg.set_item_user_data(name, cls)
-            self.tabs.append(name)
-            self.mod_widgets[name] = {
-                "buttons": [],
-                "variables": [],
-            }
+        tab = dpg.add_tab(label=name, tag=name, parent="tabbar")
+        tab_alias = dpg.get_alias_id(tab)
+        dpg.set_item_user_data(name, cls)
+        self.tabs[tab_alias] = name
+        self.widgets[name] = {
+            "buttons": {},
+            "variables": {},
+        }
 
-        dpg.add_button(label="Reload Mod", callback=self.mod_manager._gui_reload, user_data=cls._mod_name, parent=name)
+        dpg.add_button(
+            label="Reload Mod",
+            callback=self.mod_manager._gui_reload,
+            user_data=(cls._mod_name, self),
+            parent=name,
+        )
 
-        for _button in cls._gui_buttons:
+        for _button in cls._gui_buttons.values():
             self.add_button(_button)
 
-        for _variable_name, _getter in cls._gui_variables.items():
-            self.add_variable(cls, _variable_name, _getter)
+        for variable_name, getter in cls._gui_variables.items():
+            self.add_variable(cls, variable_name, getter)
+
+    def change_tab(self, sender: str, app_data: int):
+        self._current_tab = self.tabs[app_data]
 
     def add_window(self):
         with dpg.window(
@@ -134,15 +223,15 @@ class GUI:
             tag="pyMHF",
             on_close=self.exit
         ):
-            dpg.add_tab_bar(tag="tabbar")
+            dpg.add_tab_bar(tag="tabbar", callback=self.change_tab)
 
     def add_button(self, callback: ButtonProtocol):
         name = callback.__self__.__class__.__name__
         meth_name = callback.__qualname__
-        but = dpg.add_button(label=callback._button_text, callback=callback, parent=name)
-        self.mod_widgets[name]["buttons"].append((meth_name, but))
+        button = dpg.add_button(label=callback._button_text, callback=callback, parent=name)
+        self.widgets[name]["buttons"][meth_name] = button
 
-    def add_variable_gui_elements(self, cls, variable: str, getter: VariableProtocol):
+    def add_variable_gui_elements(self, cls: Mod, variable: str, getter: VariableProtocol):
         name = cls.__class__.__name__
         tag = f"{name}.{variable}"
 
@@ -150,47 +239,49 @@ class GUI:
             setattr(user_data[0], user_data[1], app_data)
 
         with dpg.group(horizontal=True, parent=name):
-            if getter._label_text is not None:
-                dpg.add_text(getter._label_text)
-            else:
-                dpg.add_text(f"{variable}: ")
+            input_id = None
+            txt_id = dpg.add_text(getter._label_text)
+            self.widgets[name]["variables"][variable] = [(txt_id, WidgetType.TEXT)]
             if getter._has_setter:
                 if getter._variable_type == VariableType.INTEGER:
-                    dpg.add_input_int(
+                    input_id = dpg.add_input_int(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
-                        on_enter=True,
+                        on_enter=False,
                     )
                 elif getter._variable_type == VariableType.STRING:
-                    dpg.add_input_text(
+                    input_id = dpg.add_input_text(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
-                        on_enter=True,
+                        on_enter=False,
                     )
                 elif getter._variable_type == VariableType.FLOAT:
-                    dpg.add_input_double(
+                    input_id = dpg.add_input_double(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
-                        on_enter=True,
+                        on_enter=False,
                     )
                 elif getter._variable_type == VariableType.BOOLEAN:
-                    dpg.add_checkbox(
+                    input_id = dpg.add_checkbox(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
                     )
+                if input_id is not None:
+                    self.widgets[name]["variables"][variable].append((input_id, WidgetType.VARIABLE))
             else:
-                dpg.add_text(source=tag)
+                txt_id = dpg.add_text(source=tag)
+                self.widgets[name]["variables"][variable].append((txt_id, WidgetType.TEXT))
 
-    def add_variable(self, cls, variable: str, getter: VariableProtocol):
-        tag = f"{cls.__class__.__name__}.{variable}"
+    def add_variable(self, cls: Mod, variable: str, getter: VariableProtocol):
+        name = cls.__class__.__name__
+        tag = f"{name}.{variable}"
         value = getattr(cls, variable)
         with dpg.value_registry():
             # If there is no setter, the value type has to be a string
-            # TODO: Check on discord if it's possible to do this some other way.
             if not getter._has_setter:
                 dpg.add_string_value(tag=tag, default_value=str(value))
             else:
@@ -203,7 +294,9 @@ class GUI:
                 elif getter._variable_type == VariableType.BOOLEAN:
                     dpg.add_bool_value(tag=tag, default_value=value)
         self.add_variable_gui_elements(cls, variable, getter)
-        self.tracking_variables.append(
+        if name not in self.tracking_variables:
+            self.tracking_variables[name] = []
+        self.tracking_variables[name].append(
             (
                 tag,
                 cls,
@@ -212,10 +305,10 @@ class GUI:
             )
         )
 
-    def remove_tab(self, cls):
+    def remove_tab(self, cls: Mod):
         """ Remove the tab associated with the provided class. """
         name = cls.__class__.__name__
-        self.tabs.remove(name)
+        self.tabs.pop(dpg.get_alias_id(name))
         dpg.delete_item(name)
 
     def run(self):
@@ -224,7 +317,8 @@ class GUI:
             dpg.set_primary_window("pyMHF", True)
             while dpg.is_dearpygui_running():
                 # For each tracking variable, update the value.
-                for tag, cls, var, is_str in self.tracking_variables:
+                for vars in self.tracking_variables.get(self._current_tab, []):
+                    tag, cls, var, is_str = vars
                     if is_str:
                         dpg.set_value(tag, str(getattr(cls, var)))
                     else:
@@ -232,8 +326,6 @@ class GUI:
                 dpg.render_dearpygui_frame()
             dpg.destroy_context()
         except:
-            from logging import getLogger
-            logger = getLogger("GuiLogger")
             logger.error("Unable to create GUI window!")
             logger.exception(traceback.format_exc())
 

--- a/pymhf/injected.py
+++ b/pymhf/injected.py
@@ -207,7 +207,7 @@ try:
         logging.exception(traceback.format_exc())
     logging.info(f"Loaded {_loaded_mods} mods and {_loaded_hooks} hooks in {time.time() - start_time:.3f}s")
 
-    # hook_manager.debug_show_states()
+    # hook_manager._debug_show_states()
 
     for func_name, hook_class in hook_manager.failed_hooks.items():
         offset = hook_class.target

--- a/pymhf/main.py
+++ b/pymhf/main.py
@@ -60,9 +60,7 @@ def get_process_when_ready(
                 parent_process = p
                 break
         if parent_process is None:
-            print("Steam not running! For now, start it yourself and try again...")
-            # TODO: Return?
-            # return
+            raise ProcessLookupError("Steam not running! For now, start it yourself and try again...")
 
     run = True
     if parent_process is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "dearpygui~=1.11.0",
   "questionary",
 ]
-version = "0.1.5"
+version = "0.1.6+dev1"
 
 [tool.setuptools.package-dir]
 pymhf = "pymhf"


### PR DESCRIPTION
This implements a functionality so that when reloading a mod, any GUI elements will be reloaded as well.
So adding a new button or variable will now be added automatically in the GUI.
This has two limitations currently:
1. You can't directly change the type of a variable. So if it was an `INTEGER` and you want to change it to a `FLOAT`, you'll need to comment out the variable and reload the mod, and then un-comment, make the change of type and then reload for it to take effect.
2. New widgets that get added are added lower down in the GUI than existing widgets (ie. they do not maintain the order as defined by the order in the mod.