### PR TITLE
gh-8: Add extra_args option to GUI field type decorators

### DIFF
--- a/pymhf/gui/decorators.py
+++ b/pymhf/gui/decorators.py
@@ -24,35 +24,68 @@ class gui_variable:
         func._label_text = label
         func._has_setter = False
 
+    @staticmethod
+    def _clean_extra_args(args: dict):
+        """ Remove any keywords from the args so that they don't override the values we need to provide. """
+        args.pop("tag", None)
+        args.pop("source", None)
+        args.pop("user_data", None)
+        args.pop("callback", None)
+        args.pop("use_internal_label", None)
+
     @classmethod
-    def INTEGER(cls, label: Optional[str] = None):
+    def INTEGER(cls, label: Optional[str] = None, **extra_args):
+        """ Create an integer entry field which can take extra arguments.
+        To see what extra arguments are available, see the DearPyGUI documentation:
+        https://dearpygui.readthedocs.io/en/latest/reference/dearpygui.html#dearpygui.dearpygui.add_input_int
+        """
         def inner(func: Callable[..., Any]) -> VariableProtocol:
             gui_variable._set_default_attributes(func, label)
             func._variable_type = VariableType.INTEGER
+            gui_variable._clean_extra_args(extra_args)
+            func._extra_args = extra_args
             return func
         return inner
 
     @classmethod
-    def STRING(cls, label: Optional[str] = None):
+    def STRING(cls, label: Optional[str] = None, **extra_args):
+        """ Create an string entry field which can take extra arguments.
+        To see what extra arguments are available, see the DearPyGUI documentation:
+        https://dearpygui.readthedocs.io/en/latest/reference/dearpygui.html#dearpygui.dearpygui.add_input_text
+        """
         def inner(func: Callable[..., Any]) -> VariableProtocol:
             gui_variable._set_default_attributes(func, label)
             func._variable_type = VariableType.STRING
+            gui_variable._clean_extra_args(extra_args)
+            func._extra_args = extra_args
             return func
         return inner
 
     @classmethod
-    def FLOAT(cls, label: Optional[str] = None):
+    def FLOAT(cls, label: Optional[str] = None, **extra_args):
+        """ Create an float entry field which can take extra arguments.
+        To see what extra arguments are available, see the DearPyGUI documentation:
+        https://dearpygui.readthedocs.io/en/latest/reference/dearpygui.html#dearpygui.dearpygui.add_input_double
+        """
         def inner(func: Callable[..., Any]) -> VariableProtocol:
             gui_variable._set_default_attributes(func, label)
             func._variable_type = VariableType.FLOAT
+            gui_variable._clean_extra_args(extra_args)
+            func._extra_args = extra_args
             return func
         return inner
 
     @classmethod
-    def BOOLEAN(cls, label: Optional[str] = None):
+    def BOOLEAN(cls, label: Optional[str] = None, **extra_args):
+        """ Create an string entry field which can take extra arguments.
+        To see what extra arguments are available, see the DearPyGUI documentation:
+        https://dearpygui.readthedocs.io/en/latest/reference/dearpygui.html#dearpygui.dearpygui.add_checkbox
+        """
         def inner(func: Callable[..., Any]) -> VariableProtocol:
             gui_variable._set_default_attributes(func, label)
             func._variable_type = VariableType.BOOLEAN
+            gui_variable._clean_extra_args(extra_args)
+            func._extra_args = extra_args
             return func
         return inner
 

--- a/pymhf/gui/gui.py
+++ b/pymhf/gui/gui.py
@@ -249,6 +249,7 @@ class GUI:
                         callback=on_update,
                         user_data=(cls, variable),
                         on_enter=False,
+                        **getter._extra_args,
                     )
                 elif getter._variable_type == VariableType.STRING:
                     input_id = dpg.add_input_text(
@@ -256,6 +257,7 @@ class GUI:
                         callback=on_update,
                         user_data=(cls, variable),
                         on_enter=False,
+                        **getter._extra_args,
                     )
                 elif getter._variable_type == VariableType.FLOAT:
                     input_id = dpg.add_input_double(
@@ -263,12 +265,14 @@ class GUI:
                         callback=on_update,
                         user_data=(cls, variable),
                         on_enter=False,
+                        **getter._extra_args,
                     )
                 elif getter._variable_type == VariableType.BOOLEAN:
                     input_id = dpg.add_checkbox(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
+                        **getter._extra_args,
                     )
                 if input_id is not None:
                     self.widgets[name]["variables"][variable].append((input_id, WidgetType.VARIABLE))

--- a/pymhf/gui/protocols.py
+++ b/pymhf/gui/protocols.py
@@ -22,6 +22,7 @@ class VariableProtocol(Protocol):
     _variable_type: VariableType
     _label_text: str
     _has_setter: bool
+    _extra_args: dict
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "dearpygui~=1.11.0",
   "questionary",
 ]
-version = "0.1.6+dev1"
+version = "0.1.6+dev2"
 
 [tool.setuptools.package-dir]
 pymhf = "pymhf"


### PR DESCRIPTION
closes #8 

I realised that instead of just adding a few random args to the decorators, it is actually easier to just allow any arguments that DearPyGUI would allow (minus some which get filtered out which we use).
This way the mod author can add any of the options that dpg offers for each type if they want to.