### PR TITLE
Allow libraries to implement a patterns lookup and fix some bugs

### DIFF
--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -2,6 +2,34 @@
 
 ## Current
 
+### 0.1.6
+
+- Add ability for GUI widgets to reload when their associated mod gets reloaded ([gh-4](https://github.com/monkeyman192/pyMHF/issues/4))
+- Add `extra_args` option to GUI field type decorators (eg, `FLOAT`) which are passed through to DearPyGui ([gh-8](https://github.com/monkeyman192/pyMHF/issues/8))
+- Fix issues with hooking multiple functions which are overloads of the same base function.
+- Add the ability for patterns to be hooked up using the `FUNC_PATTERNS` data in implementing libraries ([gh-14](https://github.com/monkeyman192/pyMHF/issues/14))
+
+### 0.1.5 (26/08/2024)
+
+- Allow overriding of function return values.
+- Fixed issue with `after` manual hooks with a `_result_` argument.
+- Implement pattern scanning functionality ([gh-1](https://github.com/monkeyman192/pyMHF/issues/1))
+
+### 0.1.4 (14/08/2024)
+
+- Overhauled config system to provide a more user-friendly experience.
+- Fixed a critical bug in hooking which meant that no result was returned.
+- Fixed an issue injecting variables into pymhf.
+
+### 0.1.3 (31/07/2024)
+
+- Implemented manual hooks. These are a decorator which have the can take an offset, name, and function definition, and allow for hooking a function without having to rely on the underlying library which utilises pymhf.
+- Made changes so that libraries can be installed as plugins to pymhf so that they can be run like `pymhf <libname>`
+
+### 0.1.2 (15/07/2024)
+
+- Made improvements to config reading
+
 ### 0.1.1 (05/07/2024)
 
 - Fixed issues loading applications which aren't loaded with steam.

--- a/pymhf/core/_types.py
+++ b/pymhf/core/_types.py
@@ -19,6 +19,7 @@ class HookProtocol(Protocol):
     _hook_func_name: str
     _hook_time: DetourTime
     _custom_trigger: Optional[str]
+    _func_overload: Optional[str]
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         ...
@@ -29,3 +30,4 @@ class ManualHookProtocol(HookProtocol):
     _hook_pattern: Optional[str]
     _hook_binary: Optional[str]
     _hook_func_def: FUNCDEF
+    _func_overload: Optional[str]

--- a/pymhf/core/calling.py
+++ b/pymhf/core/calling.py
@@ -40,7 +40,12 @@ def call_function(
     if pattern:
         offset = find_pattern_in_binary(pattern, False)
     else:
-        offset = module_data.FUNC_OFFSETS[name]
+        if (_pattern := module_data.FUNC_PATTERNS.get(name)) is not None:
+            offset = find_pattern_in_binary(_pattern, False)
+        else:
+            offset = module_data.FUNC_OFFSETS.get(name)
+        if offset is None:
+            raise NameError(f"Cannot find function {name}")
     if isinstance(_sig, FUNCDEF):
         sig = CFUNCTYPE(_sig.restype, *_sig.argtypes)
     else:

--- a/pymhf/core/memutils.py
+++ b/pymhf/core/memutils.py
@@ -262,7 +262,8 @@ def find_pattern_in_binary(
     handle, module = hm_cache[binary]
     patt = pattern_to_bytes(pattern)
     _offset = pymem.pattern.pattern_scan_module(handle, module, patt, return_multiple=return_multiple)
-    _offset = _offset - module.lpBaseOfDll
+    if _offset:
+        _offset = _offset - module.lpBaseOfDll
     # Cache even if there is no result (so we don't repeatedly look for it when it's not there in case there
     # is an issue.)
     offset_cache[key] = _offset

--- a/pymhf/core/module_data.py
+++ b/pymhf/core/module_data.py
@@ -5,9 +5,17 @@ from typing import Union
 
 from pymhf.core._types import FUNCDEF
 
+# Load order:
+# 1. Look up offsets based on binary hash in offset cache (#TODO: implement)
+# 2. Look up patterns
+# 3. Use offsets
+
+# NOTE: The above is just temporary. Need to figure out a more robust way to specify this.
+# (Well, the order of 2 and 3 should be swapped likely. Need a way to specify which to use...)
 
 class ModuleData:
     FUNC_OFFSETS: dict[str, Union[int, dict[str, int]]]
+    FUNC_PATTERNS: dict[str, Union[str, dict[str, str]]]
     FUNC_CALL_SIGS: dict[str, Union[FUNCDEF, dict[str, FUNCDEF]]]
 
 

--- a/pymhf/gui/gui.py
+++ b/pymhf/gui/gui.py
@@ -244,35 +244,40 @@ class GUI:
             self.widgets[name]["variables"][variable] = [(txt_id, WidgetType.TEXT)]
             if getter._has_setter:
                 if getter._variable_type == VariableType.INTEGER:
+                    extra_args = {"on_enter": False}
+                    extra_args.update(getter._extra_args)
                     input_id = dpg.add_input_int(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
-                        on_enter=False,
-                        **getter._extra_args,
+                        **extra_args,
                     )
                 elif getter._variable_type == VariableType.STRING:
+                    extra_args = {"on_enter": False}
+                    extra_args.update(getter._extra_args)
                     input_id = dpg.add_input_text(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
-                        on_enter=False,
-                        **getter._extra_args,
+                        **extra_args,
                     )
                 elif getter._variable_type == VariableType.FLOAT:
+                    extra_args = {"on_enter": False}
+                    extra_args.update(getter._extra_args)
                     input_id = dpg.add_input_double(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
-                        on_enter=False,
-                        **getter._extra_args,
+                        **extra_args,
                     )
                 elif getter._variable_type == VariableType.BOOLEAN:
+                    extra_args = {}
+                    extra_args.update(getter._extra_args)
                     input_id = dpg.add_checkbox(
                         source=tag,
                         callback=on_update,
                         user_data=(cls, variable),
-                        **getter._extra_args,
+                        **extra_args,
                     )
                 if input_id is not None:
                     self.widgets[name]["variables"][variable].append((input_id, WidgetType.VARIABLE))

--- a/pymhf/injected.py
+++ b/pymhf/injected.py
@@ -60,8 +60,9 @@ try:
     module = import_file(_internal.MODULE_PATH)
 
     from pymhf.core.module_data import module_data
-    module_data.FUNC_OFFSETS = module.__pymhf_functions__.FUNC_OFFSETS
-    module_data.FUNC_CALL_SIGS = module.__pymhf_functions__.FUNC_CALL_SIGS
+    module_data.FUNC_OFFSETS = getattr(module.__pymhf_functions__, "FUNC_OFFSETS", {})
+    module_data.FUNC_PATTERNS = getattr(module.__pymhf_functions__, "FUNC_PATTERNS", {})
+    module_data.FUNC_CALL_SIGS = getattr(module.__pymhf_functions__, "FUNC_CALL_SIGS", {})
 
     from pymhf.core.hooking import hook_manager
     from pymhf.core.protocols import (

--- a/pymhf/injected.py
+++ b/pymhf/injected.py
@@ -180,12 +180,13 @@ try:
         # If the mod folder isn't absolute, assume it's relative to the library directory.
         if not op.isabs(internal_mod_folder):
             internal_mod_folder = op.join(_internal.MODULE_PATH, internal_mod_folder)
-        if not op.exists(internal_mod_folder):
+        if op.exists(internal_mod_folder):
+            mod_manager.load_mod_folder(internal_mod_folder, bind=False)
+        else:
             logging.warning(
                 f"Cannot load internal mod directory: {internal_mod_folder}. "
                 "Please make sure it exists or that the path is correct in the pymhf.cfg file."
             )
-        mod_manager.load_mod_folder(internal_mod_folder, bind=False)
 
     logging.info("pyMHF injection complete!")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "dearpygui~=1.11.0",
   "questionary",
 ]
-version = "0.1.6+dev2"
+version = "0.1.6+dev3"
 
 [tool.setuptools.package-dir]
 pymhf = "pymhf"


### PR DESCRIPTION
closes #14 

Libraries can now add a pattern lookup which contains a dictionary with the keys being function names, and the values being patterns.

This is implemented by having a `patterns.py` file in the `data.functions` directory which looks a little like this:

```py
from typing import Union
FUNC_PATTERNS: dict[str, Union[str, dict[str, str]]] = {
    "cGcPlayerState::AwardUnits": "48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 40 44 8B 81 BC",
    "cGcPlayerState::RemoveUnits": "40 53 48 83 EC 40 44 8B 81 BC",
    "cGcPlayerState::Construct": "40 55 53 57 41 55 41 57 48 8B",
}
```

This is then imported in `data.functions.__init__.py` like:
```py
from .patterns import FUNC_PATTERNS  # noqa
```

TODO:
- [x] Allow for overloads