### PR TITLE
Improve safety of hooking functions and keyboard bindings and GUI fix

### DIFF
--- a/pymhf/core/_types.py
+++ b/pymhf/core/_types.py
@@ -12,6 +12,11 @@ class DetourTime(Enum):
     AFTER = 2
 
 
+class KeyPressProtocol(Protocol):
+    _hotkey: str
+    _hotkey_press: str
+
+
 class HookProtocol(Protocol):
     _is_funchook: bool
     _is_manual_hook: bool

--- a/pymhf/core/importing.py
+++ b/pymhf/core/importing.py
@@ -45,4 +45,4 @@ def import_file(fpath: str) -> Optional[ModuleType]:
             print("failed")
     except Exception:
         logger.error(f"Error loading {fpath}")
-        logger.exception(traceback.format_exc())
+        logger.error(traceback.format_exc())

--- a/pymhf/core/mod_loader.py
+++ b/pymhf/core/mod_loader.py
@@ -23,7 +23,7 @@ from pymhf.core.errors import NoSaveError
 import pymhf.core._internal as _internal
 from pymhf.core.hooking import HookManager
 import pymhf.core.common as common
-from pymhf.core.utils import does_pid_have_focus
+from pymhf.core.utils import does_pid_have_focus, saferun
 from pymhf.core._types import HookProtocol
 from pymhf.gui.protocols import ButtonProtocol, VariableProtocol
 
@@ -316,7 +316,7 @@ class ModManager():
                     e.name == name and
                     e.event_type == event_type and
                     does_pid_have_focus(_internal.PID) and
-                    func()
+                    saferun(func)
                 )
             )
             self.hotkey_callbacks[
@@ -385,4 +385,4 @@ class ModManager():
             else:
                 mod_logger.error(f"Cannot find mod {name}")
         except:
-            mod_logger.exception(traceback.format_exc())
+            mod_logger.error(traceback.format_exc())

--- a/pymhf/core/utils.py
+++ b/pymhf/core/utils.py
@@ -1,8 +1,12 @@
 from ctypes import windll, create_unicode_buffer, byref, c_ulong
 from configparser import ConfigParser
+import logging
 from typing import Optional
 
 # from pymhf import _internal
+
+
+logger = logging.getLogger(__name__)
 
 
 # def dump_resource(res, fname):
@@ -64,5 +68,14 @@ class AutosavingConfig(ConfigParser):
             with open(self._filename, "w", encoding=self._encoding) as f:
                 self.write(f, space_around_delimiters=True)
         except Exception as e:
-            import logging
-            logging.exception(e)
+            logger.exception("Error saving file")
+
+
+def saferun(func, *args, **kwargs):
+    """ Safely run the specified function with args and kwargs. Any exception raised will be shown and """
+    ret = None
+    try:
+        ret = func(*args, **kwargs)
+    except:
+        logger.exception(f"There was an exception while calling {func}:")
+    return ret

--- a/pymhf/gui/gui.py
+++ b/pymhf/gui/gui.py
@@ -1,5 +1,4 @@
 from enum import Enum
-import traceback
 import logging
 from typing import TypedDict, Union, Optional
 # import win32gui
@@ -144,6 +143,7 @@ class GUI:
         removed_buttons = existing_button_names - mod_button_names
         for button_name in removed_buttons:
             dpg.delete_item(button_widgets[button_name])
+            button_widgets.pop(button_name)
 
     def reload_variables(self, cls: Mod, widgets: Widgets):
         """ Reload all variables associated with a mod.
@@ -178,6 +178,7 @@ class GUI:
             dpg.delete_item(tag)
             for var_id, _ in variable_widgets[variable_name]:
                 dpg.delete_item(var_id)
+            variable_widgets.pop(variable_name)
 
 
     def add_tab(self, cls: Mod):
@@ -335,8 +336,7 @@ class GUI:
                 dpg.render_dearpygui_frame()
             dpg.destroy_context()
         except:
-            logger.error("Unable to create GUI window!")
-            logger.exception(traceback.format_exc())
+            logger.exception("Unable to create GUI window!")
 
     def exit(self):
         dpg.stop_dearpygui()

--- a/pymhf/injected.py
+++ b/pymhf/injected.py
@@ -206,7 +206,7 @@ try:
                 Please do so so that you can load mods."""
             )
     except:
-        logging.exception(traceback.format_exc())
+        logging.error(traceback.format_exc())
     logging.info(f"Loaded {_loaded_mods} mods and {_loaded_hooks} hooks in {time.time() - start_time:.3f}s")
 
     # hook_manager._debug_show_states()
@@ -257,7 +257,7 @@ except Exception as e:
             traceback.print_exc(file=f)
             if socket_logger_loaded:
                 logging.error("An error occurred while loading pymhf:")
-                logging.exception(traceback.format_exc())
+                logging.error(traceback.format_exc())
     except:
         with open(op.join(op.expanduser("~"), "CRITICAL_ERROR.txt"), "w") as f:
             traceback.print_exc(file=f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "dearpygui~=1.11.0",
   "questionary",
 ]
-version = "0.1.7+dev1"
+version = "0.1.7+dev2"
 
 [tool.setuptools.package-dir]
 pymhf = "pymhf"


### PR DESCRIPTION
So I never implemented a way to catch exceptions in detours in the compound hook because I hadn't thought of a good way to implement it without wrapping every single call in a try...except to avoid any extra minimal overhead of a using a try..except.
I think this solution is fine since it will only add 2 try...except's per hooked function, instead of one per detour.

This also fixes a small error I found when removing a button or variable from the GUI and then reloading again (it would error out and be stuck)

Finally, cleaned up the logging around errors and also added a `saferun` function which is currently used for just calling the functions bound to a key press/release so that any exceptions there are automatically caught also.