### PR TITLE
Documentation update and minor correction

### DIFF
--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -10,7 +10,7 @@
 - Added an `pymhf.core.hooking.exported` hook to allow hooking functions which are exported by the main exe.
 - Added the `pymhf.core.calling.call_exported` function which allows exported functions by the game to be called.
 - Added the ability to specify in the `pymhf.core.hooking.imported` decorator whether the detour time is `"before"` or `"after"`.
-- Fixed an issue where hooks defined using the `manual_hook` decorator didn't use the `__pymhf_func_offsets__` etc. variables defined. (Thanks to `._harmonic` on discord for finding the bug.)
+- Fixed an issue where hooks defined using the `manual_hook` decorator didn't use the `__pymhf_func_offsets__` etc. variables defined. (Thanks to [@hashcatHitman](https://www.github.com/hashcatHitman) for finding the bug.)
 - Made improvements to the shutting down of `pyMHF` so that when the process it is attached to exits, so does `pyMHF`.
 - Added a class decorator `partial_struct` in `pymhf.utils.partial_struct` which can be used to creat `ctypes.Structure` types without needing to know the entire layout of the struct.
 

--- a/docs/single_file_mods.md
+++ b/docs/single_file_mods.md
@@ -66,7 +66,7 @@ To modify the above script, the only values that really need to be changed are t
 If the game is being ran via steam, replace `steam_gameid` with the value found in steam, and set `exe` to be the name of the game binary.
 If the game or program is not run through steam, remove the `steam_gameid` value and instead set `exe` and the absolute path to the binary.
 
-Note that by default the GUI will not be installed by uv. If you want the GUI to be included, add the `[gui]` extra to your script dependecies metadata, like so:
+Note that by default the GUI will not be installed by uv and is only available on 64-bit installations of Python due to DearPyGui lacking support for 32-bit. If you want the GUI to be included, add the `[gui]` extra to your script dependecies metadata, like so:
 
 ```py
 # /// script

--- a/docs/single_file_mods.md
+++ b/docs/single_file_mods.md
@@ -65,3 +65,12 @@ To modify the above script, the only values that really need to be changed are t
 
 If the game is being ran via steam, replace `steam_gameid` with the value found in steam, and set `exe` to be the name of the game binary.
 If the game or program is not run through steam, remove the `steam_gameid` value and instead set `exe` and the absolute path to the binary.
+
+Note that by default the GUI will not be installed by uv. If you want the GUI to be included, add the `[gui]` extra to your script dependecies metadata, like so:
+
+```py
+# /// script
+# dependencies = ["pymhf[gui]"]
+# 
+... (truncated)
+```


### PR DESCRIPTION
Adds a note to the single file mod documentation mentioning the additional script metadata required for uv to install the DearPyGUI dependency.

Also changes the attribution in the changelog to refer to my GitHub account instead of an ephemeral Discord account.

Resolves #38