### PR TITLE
Extra functionality wrt partial structs and some doc improvements

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -91,8 +91,8 @@ jobs:
 
   test-release:
     name: Release pyMHF wheels and source build to test-PyPI
-    # Only release to the test PyPI if we have merged into master.
-    if: github.ref == 'refs/heads/master'
+    # Release to the test PyPI if we have merged into master or if we have tagged.
+    if: ${{ (github.ref == 'refs/heads/master') || startsWith(github.ref, 'refs/tags') }}
     needs:
       - build_test
     runs-on: ubuntu-latest

--- a/docs/docs/change_log.rst
+++ b/docs/docs/change_log.rst
@@ -8,6 +8,7 @@ Current (0.1.12-dev)
 - Improved inter-mod communication.
 - Added the ability to specify the total size of a partial struct using the ``_total_size_`` attribute. This will be utilised more in some upcoming changes which should simplify initialization of structs from memory using hooked functions.
 - Added a new way to specify the data required for hooking and calling functions. See :doc:`here </docs/creating_hook_definitions>` for more details. This method will completely replace the old method of using the ``__pymhf_func_offsets__`` etc. "magic" mod attributes.
+- Added a :py:func:`~pymhf.extensions.ctypes.c_enum32` type which can be used to construct enums as fields.
 
 0.1.11 (29/04/2025)
 --------------------

--- a/docs/docs/extension_types.rst
+++ b/docs/docs/extension_types.rst
@@ -1,0 +1,35 @@
+Extension types
+===============
+
+pyMHF provides a number of extra types which can be used to either extend the built-in python ctypes library, or interface with c++ code more easily.
+
+.. note::
+    These types should be considered experimental unless otherwise specified.
+
+
+ctypes extensions
+-----------------
+
+:py:class:`~pymhf.extensions.ctypes.c_enum32`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This class is a wrapper around the ``ctypes.c_uint32`` type, but it's able to be subscripted to provide a concrete type based on the ``IntEnum`` used.
+
+For example, consider the following code:
+
+.. code-block:: py
+
+    from pymhf.utils.partial_struct import partial_struct
+    import ctypes
+    from enum import IntEnum
+    from typing import Annotated
+
+    class States(IntEnum):
+        OFF = 0
+        ON = 1
+        UNDEFINED = 2
+
+    @partial_struct
+    class Test(ctypes.Structure):
+        a: Annotated[c_enum32[States], 0x0]
+        b: Annotated[ctypes.c_uint32, 0x10]

--- a/docs/docs/index.rst
+++ b/docs/docs/index.rst
@@ -11,6 +11,7 @@ Usage guide
    inter_mod_functionality
    partial_structs
    single_file_mods
+   extension_types
    libraries/index
    gui/index
    change_log

--- a/docs/docs/writing_mods.rst
+++ b/docs/docs/writing_mods.rst
@@ -24,6 +24,11 @@ pyMHF provides functionality to allow these detours to be run *before* or *after
 
 A *before* detour is used when you want to have something occur before the original function has been run. This may be to change the value in some internal struct/class so that when the original function runs it is run on some different value, or it may be to pass in different arguments to the original function.
 
+You can indicate to pyMHF that you want to change the arguments the original function is called with by simply returning the new values you want.
+
+.. note::
+    The values passed must be a complete set of arguments. So if a function has 3 arguments, but you only want to modify 1 of them, you still need to return all 3 arguments (with the one replaced with the value required) in their original order.
+
 *After* detours
 """""""""""""""
 

--- a/pymhf/core/__init__.py
+++ b/pymhf/core/__init__.py
@@ -1,13 +1,15 @@
 import ctypes
 import typing
+from ctypes import _Pointer
 
 from ._types import DetourTime  # noqa
 
 # Monkeypatch typed _Pointer from typeshed into ctypes.
 # c/o https://github.com/python/mypy/issues/7540#issuecomment-845741357
 if not typing.TYPE_CHECKING:
+    ctypes._Pointer_orig = _Pointer
 
-    class _Pointer:
+    class _Pointer(ctypes._Pointer):
         def __class_getitem__(cls, item):
             return ctypes.POINTER(item)
 

--- a/pymhf/extensions/ctypes.py
+++ b/pymhf/extensions/ctypes.py
@@ -1,0 +1,36 @@
+# Some extenions to ctypes to add some extra functionality
+
+import ctypes
+import types
+from enum import IntEnum
+from typing import Generic, Type, TypeVar
+
+_cenum_type_cache = {}
+
+T = TypeVar("T", bound=IntEnum)
+
+
+class c_enum32(ctypes.c_int32, Generic[T]):
+    """c_int32 wrapper for enums. This doesn't have the full set of features an enum would normally have,
+    but just enough to make it useful."""
+
+    _enum_type: IntEnum
+
+    def __repr__(self):
+        return self._enum_type(self.value).__repr__()
+
+    def __eq__(self, other):
+        return other == self.value
+
+    def __class_getitem__(cls: Type["c_enum32"], enum_type: Type[IntEnum]):
+        """Get the actual concrete type based on the enum_type provided.
+        This will be cached so we only generate one instance of the type per IntEnum."""
+        if not issubclass(enum_type, IntEnum):
+            raise TypeError(f"Indexed type {enum_type!r} of type {enum_type} is not an IntEnum")
+        if enum_type in _cenum_type_cache:
+            return _cenum_type_cache[enum_type]
+        else:
+            _cls: c_enum32 = types.new_class(f"c_enum32[{enum_type}]", (c_enum32,))
+            _cls._enum_type = enum_type
+            _cenum_type_cache[enum_type] = _cls
+            return _cls

--- a/pymhf/utils/partial_struct.py
+++ b/pymhf/utils/partial_struct.py
@@ -1,10 +1,23 @@
 import ctypes
+import inspect
 from dataclasses import dataclass
-from typing import Annotated, Optional, Type, TypeVar, cast
+from typing import Optional, Type, TypeVar, Union, _AnnotatedAlias, get_args
 
 from typing_extensions import get_type_hints
 
-StructType = TypeVar("StructType", bound=Type[ctypes.Structure])
+from pymhf.extensions.ctypes import c_enum32
+
+_T = TypeVar("_T", bound=Type[ctypes.Structure])
+
+CTYPES = Union[
+    ctypes._SimpleCData,
+    ctypes.Structure,
+    ctypes._Pointer,
+    ctypes._Pointer_orig,  # The original, un-monkeypatched ctypes._Pointer object
+    ctypes.Array,
+    ctypes.Union,
+    c_enum32,
+]
 
 
 @dataclass
@@ -13,10 +26,19 @@ class Field:
     offset: Optional[int] = None
 
 
-def partial_struct(cls: StructType):
+def partial_struct(cls: _T) -> _T:
     """Mark the decorated class as a partial struct.
     This will automatically construct the ``_field_`` attribute for this class
     """
+    # Always get the calling frame and add the locals so that if we have any annotated fields they won't fail.
+    # In the case of a struct which has no annotations this will be ever so slightly slower than if we did a
+    # try... except.
+    # However in the case of annotated fields, it's much faster, so it's beneficial to always do this.
+    calling_frame = None
+    if (cframe := inspect.currentframe()) is not None:
+        calling_frame = cframe.f_back
+    if calling_frame is not None:
+        locals().update(calling_frame.f_locals)
     _fields_ = []
     curr_position = 0
     total_size = getattr(cls, "_total_size_", 0)
@@ -25,18 +47,39 @@ def partial_struct(cls: StructType):
         cls._fields_ = _fields_
         return cls
     # If there are, loop over the annotations and extract the info we need to construct the _fields_.
-    for field_name, annotation in get_type_hints(cls, include_extras=True).items():
-        if len(annotation.__metadata__) == 1:
-            field_data = annotation.__metadata__[0]
+    for field_name, annotation in get_type_hints(cls, include_extras=True, localns=locals()).items():
+        if not isinstance(annotation, _AnnotatedAlias):
+            # In this case it's just the type.
+            field_type = annotation
+            field_offset = None
         else:
-            raise ValueError(f"The field {field_name} has an invalid annotation: {annotation}")
-        field_data = cast(Field, field_data)
-        field_type = field_data.datatype
-        field_offset = field_data.offset
+            # If the annotation is a Field object, get info from it, otherwise it must be an integer
+            # specifying the offset.
+            metadata = annotation.__metadata__
+            if len(metadata) != 1:
+                raise ValueError(f"The field {field_name!r} has an invalid annotation: {annotation}")
+            metadata = metadata[0]
+            if isinstance(metadata, Field):
+                field_type = metadata.datatype
+                field_offset = metadata.offset
+            else:
+                field_type = annotation.__origin__
+                field_offset = metadata
+        if not issubclass(field_type, get_args(CTYPES)):
+            raise ValueError(f"The field {field_name!r} has an invalid type: {field_type}")
+        if field_offset is not None and not isinstance(field_offset, int):
+            raise ValueError(f"The field {field_name!r} has an invalid offset: {field_offset!r}")
         if field_offset and field_offset > curr_position:
             padding_bytes = field_offset - curr_position
             _fields_.append((f"_padding_{curr_position:X}", ctypes.c_ubyte * padding_bytes))
             curr_position += padding_bytes
+        field_alignment = ctypes.alignment(field_type)
+        if curr_position % field_alignment != 0:
+            # If the field is not aligned to the correct position, then move the current position forward
+            # to ensure it's right.
+            # Don't bother adding this as padding since it will just add extra unnecessary fields.
+            diff = field_alignment - (curr_position % field_alignment)
+            curr_position += diff
         _fields_.append((field_name, field_type))
         curr_position += ctypes.sizeof(field_type)
     if total_size and curr_position < total_size:
@@ -44,22 +87,3 @@ def partial_struct(cls: StructType):
         _fields_.append((f"_padding_{curr_position:X}", ctypes.c_ubyte * padding_bytes))
     cls._fields_ = _fields_
     return cls
-
-
-if __name__ == "__main__":
-
-    @partial_struct
-    class Test(ctypes.Structure):
-        _total_size_ = 24
-        a: Annotated[int, Field(ctypes.c_uint32)]
-        b: Annotated[int, Field(ctypes.c_uint32, 0x10)]
-
-    print(Test._fields_)
-    data = bytearray(
-        b"\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00"
-    )
-    t = Test.from_buffer(data)
-    print(t.a)
-    print(t.b)
-
-    print(bytes(t))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ gui = [
 [dependency-groups]
 dev = [
   "pytest",
+  "pytest-benchmark",
   "ruff",
   "setuptools_scm",
   "twine",

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
 wheels = [
@@ -636,6 +636,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335 },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +737,7 @@ dev = [
     { name = "esbonio" },
     { name = "pydata-sphinx-theme" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -759,6 +769,7 @@ dev = [
     { name = "esbonio" },
     { name = "pydata-sphinx-theme" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "sphinx" },
@@ -3293,6 +3304,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d0/a8bd08d641b393db3be3819b03e2d9bb8760ca8479080a26a5f6e540e99c/pytest-benchmark-5.1.0.tar.gz", hash = "sha256:9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105", size = 337810 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/d6/b41653199ea09d5969d4e385df9bbfd9a100f28ca7e824ce7c0a016e3053/pytest_benchmark-5.1.0-py3-none-any.whl", hash = "sha256:922de2dfa3033c227c96da942d1878191afa135a29485fb942e85dff1c592c89", size = 44259 },
 ]
 
 [[package]]


### PR DESCRIPTION
Improved the partial struct functionality, including cleaning up some typing issues.

Also added a new `c_enum32` type as part of the `pymhf.extensions.ctypes` module which can be used to designate enum types. Will probably add more types once I'm sure this works well.