### PR TITLE
typing, library path injection, and `this` as ptr fixes

### DIFF
--- a/docs/docs/writing_mods.rst
+++ b/docs/docs/writing_mods.rst
@@ -13,6 +13,8 @@ The main body of the mod file is the :class:`pymhf.core.mod_loader.Mod` class wh
 Without any hooks or functions defined, this mod won't do very much, so the first thing to do is determine what the contents of the mod should be.
 We can break this up into two categories; hooking functionality and non-hooking functionality.
 
+.. _writing_mods_hooking_functionality:
+
 Hooking Functionality
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/pymhf/core/logging.py
+++ b/pymhf/core/logging.py
@@ -1,5 +1,6 @@
 import subprocess
 from multiprocessing.connection import Connection
+from typing import Optional
 
 import psutil
 
@@ -15,7 +16,7 @@ class stdoutSocket:
         pass
 
 
-def open_log_console(log_script: str, log_dir: str, name_override: str = "pymhf console") -> int:
+def open_log_console(log_script: str, log_dir: str, name_override: str = "pymhf console") -> Optional[int]:
     """Open the logging console and return the pid of it.
 
     Parameters

--- a/pymhf/core/memutils.py
+++ b/pymhf/core/memutils.py
@@ -155,8 +155,9 @@ def get_field_info(obj, logger=None, indent: int = 0, as_hex: bool = True, max_d
                     yield _msg
 
 
-def get_addressof(obj) -> int:
-    """Get the address in memory of some object."""
+def get_addressof(obj: CTYPES) -> int:
+    """Get the address in memory of some object.
+    If obj is a pointer, this will return the address pointed to."""
     try:
         # If it's a pointer, this is the branch that is used.
         return ctypes.cast(obj, ctypes.c_void_p).value

--- a/pymhf/extensions/ctypes.py
+++ b/pymhf/extensions/ctypes.py
@@ -14,15 +14,26 @@ class c_enum32(ctypes.c_int32, Generic[T]):
     """c_int32 wrapper for enums. This doesn't have the full set of features an enum would normally have,
     but just enough to make it useful."""
 
-    _enum_type: IntEnum
+    _enum_type: Type[T]
+
+    @property
+    def _enum_value(self):
+        return self._enum_type(self.value)
+
+    @property
+    def name(self):
+        return self._enum_value.name
+
+    def __str__(self):
+        return self._enum_value.__str__()
 
     def __repr__(self):
-        return self._enum_type(self.value).__repr__()
+        return self._enum_value.__repr__()
 
     def __eq__(self, other):
         return other == self.value
 
-    def __class_getitem__(cls: Type["c_enum32"], enum_type: Type[IntEnum]):
+    def __class_getitem__(cls: Type["c_enum32"], enum_type: Type[T]):
         """Get the actual concrete type based on the enum_type provided.
         This will be cached so we only generate one instance of the type per IntEnum."""
         if not issubclass(enum_type, IntEnum):
@@ -30,7 +41,7 @@ class c_enum32(ctypes.c_int32, Generic[T]):
         if enum_type in _cenum_type_cache:
             return _cenum_type_cache[enum_type]
         else:
-            _cls: c_enum32 = types.new_class(f"c_enum32[{enum_type}]", (c_enum32,))
+            _cls: Type[c_enum32[T]] = types.new_class(f"c_enum32[{enum_type}]", (c_enum32,))
             _cls._enum_type = enum_type
             _cenum_type_cache[enum_type] = _cls
             return _cls

--- a/pymhf/utils/config.py
+++ b/pymhf/utils/config.py
@@ -10,9 +10,9 @@ def canonicalize_setting(
     value: Optional[str],
     plugin_name: Optional[str],
     module_dir: str,
-    exe_dir: str,
+    exe_dir: Optional[str] = None,
     suffix: Optional[str] = None,
-) -> str:
+) -> Optional[str]:
     """Convert the "magic" names into real values.
 
     Possible keys:
@@ -39,7 +39,7 @@ def canonicalize_setting(
         elif value == "~":
             tag = "USER_DIR"
         elif not op.exists(value):
-            raise ValueError(f"Invalid path: {value}")
+            raise ValueError(f"Path doesn't exist: {value}")
 
     # If the path provided already exists, simply return it.
     if tag is None and op.exists(value):

--- a/pymhf/utils/parse_toml.py
+++ b/pymhf/utils/parse_toml.py
@@ -25,7 +25,7 @@ def read_inline_metadata(script: str) -> Optional[tomlkit.TOMLDocument]:
         return None
 
 
-def _parse_toml(fpath: str, standalone: bool = False) -> dict:
+def _parse_toml(fpath: str, standalone: bool = False) -> Optional[dict]:
     settings = {}
     with open(fpath, "r") as f:
         if standalone:

--- a/pymhf/utils/partial_struct.py
+++ b/pymhf/utils/partial_struct.py
@@ -22,7 +22,7 @@ CTYPES = Union[
 
 @dataclass
 class Field:
-    datatype: ctypes.Structure
+    datatype: CTYPES
     offset: Optional[int] = None
 
 


### PR DESCRIPTION
As part of the process of getting NMS.py ready for release, I did some deeper testing and found a few issues with not only the `this` type (it was expecting it to always be an int type), but also with loading libraries directly from pymhf.

Both of these issues have been fixed, and also type hints have been improved across the board. Still quite a few typing issues internally, but at least most of the public facing functions should be mostly fine (in some cases it's not really possible to make it better without changing the field types for function definitions to be Annotations instead of just the plain ctype object.
Not sure if I like the idea of making this change since the code will be much more verbose to define, but it could be optional.