### PR TITLE
gh-53: Update internal handling of hooks and mods

### DIFF
--- a/docs/docs/change_log.rst
+++ b/docs/docs/change_log.rst
@@ -6,6 +6,9 @@ Current (0.1.14.dev)
 - Added the ability for partial classes to subclass from another partial struct or ``ctypes.Structure``.
 - Change mod folder loading so that it will load from sub-folders as well. (`#64 <https://github.com/monkeyman192/pyMHF/issues/64>`_)
 - Implement a offset cache - This will reduce start up times after the initial load for any pattern which has already been found for the same binary. (`#2 <https://github.com/monkeyman192/pyMHF/issues/2>`_)
+- Changed the `@disable` decorator so that it can be applied to mods as well as hooks.
+- Made some internal changes so that mods which define the same hook (whether by having the same pattern or a different one that resolves to the same offset) will not cause a clash. (`#53 <https://github.com/monkeyman192/pyMHF/issues/53>`_)
+- Fixed an issue that meant that the numbers logged for loaded mods and hooks wasn't correct.
 
 0.1.13 (26/06/2025)
 -------------------

--- a/pymhf/core/_types.py
+++ b/pymhf/core/_types.py
@@ -2,6 +2,21 @@ from enum import Enum
 from typing import Any, NamedTuple, Optional, Protocol
 
 
+class FunctionIdentifier(NamedTuple):
+    name: str
+    offset: int
+    binary: str
+    is_absolute: bool
+
+    def __eq__(self, other: "FunctionIdentifier"):
+        """Two FunctionIdentifier's are the same if their offset and binary are the same."""
+        return self.offset == other.offset and self.binary == other.binary
+
+    def __hash__(self):
+        """Only use the offset and binary values for the hash. Name doesn't matter."""
+        return hash((self.offset, self.binary))
+
+
 # TODO: Fully deprecate.
 class FUNCDEF(NamedTuple):
     restype: Any
@@ -35,7 +50,7 @@ class HookProtocol(Protocol):
     _func_overload: Optional[str]
     _get_caller: Optional[bool]
     _noop: Optional[bool]
-    _dll_name: str
+    _dll_name: Optional[str]
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 

--- a/pymhf/core/calling.py
+++ b/pymhf/core/calling.py
@@ -12,6 +12,9 @@ from pymhf.core.utils import saferun_decorator
 calling_logger = getLogger("CallingManager")
 
 
+# TODO: Everything in this file is deprecated. DO NOT use it.
+
+
 @saferun_decorator
 def call_exported(name: str, func_def: FUNCDEF, *args):
     """Call a function exported by the main binary.

--- a/pymhf/core/module_data.py
+++ b/pymhf/core/module_data.py
@@ -18,4 +18,5 @@ class ModuleData:
     FUNC_BINARY: Optional[str] = None
 
 
+# TODO: Remove.
 module_data = ModuleData()

--- a/pymhf/injected.py
+++ b/pymhf/injected.py
@@ -217,7 +217,7 @@ try:
             _loaded_mods, _loaded_hooks = mod_manager.load_single_mod(_internal.MODULE_PATH)
         elif _internal.LOAD_TYPE == _internal.LoadTypeEnum.MOD_FOLDER:
             _loaded_mods, _loaded_hooks = mod_manager.load_mod_folder(_internal.MODULE_PATH, deep_search=True)
-        else:
+        else:  # Loading a library.
             if mod_folder is not None:
                 _loaded_mods, _loaded_hooks = mod_manager.load_mod_folder(mod_folder, deep_search=True)
             else:
@@ -227,7 +227,16 @@ try:
                 )
     except Exception:
         logging.error(traceback.format_exc())
-    logging.info(f"Loaded {_loaded_mods} mods and {_loaded_hooks} hooks in {time.time() - start_time:.3f}s")
+    _mods_str = "mod"
+    if _loaded_mods != 1:
+        _mods_str = "mods"
+    _hooks_str = "hook"
+    if _loaded_hooks != 1:
+        _hooks_str = "hooks"
+    logging.info(
+        f"Loaded {_loaded_mods} {_mods_str} and {_loaded_hooks} {_hooks_str} in "
+        f"{time.time() - start_time:.3f}s"
+    )
 
     mod_manager._assign_mod_instances()
 


### PR DESCRIPTION
Main changes here are to move away from using the user-defined names for hooks as the identifier and instead when a hook is defined and known to be loaded, determine the relative offset within a binary and use this offset and binary as the unique key for a hook.
This way, if two mods provide the same (or different) pattern which points to the same in-game function they won't clash, but instead be realised to be the same function.

Also fixed a few little issues such as the `@disable` decorator not working on a mod like it should have, and an issue with logging the count of loaded mods (caused I think by the ability to load nested mod folders...)