### PR TITLE
Fixes relating to this_is_pointer and mod folders

### DIFF
--- a/docs/docs/change_log.rst
+++ b/docs/docs/change_log.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Current (0.1.15.dev)
+--------------------
+
+- Fixed an issue where the `this` argument wouldn't get correctly determined to be a pointer.
+- Added the configured mod directory to the system path to aide in inter-mod communication.
+
 0.1.14 (09/07/2025)
 -------------------
 

--- a/pymhf/core/__init__.py
+++ b/pymhf/core/__init__.py
@@ -16,6 +16,7 @@ if not typing.TYPE_CHECKING:
     ctypes._Pointer = _Pointer
 
 
+# TODO: Assess whether we need this any more...
 def pymhf_overload(func):
     setattr(func, "_is_overloaded", True)
     return func

--- a/pymhf/core/memutils.py
+++ b/pymhf/core/memutils.py
@@ -76,7 +76,7 @@ def match(patt: bytes, input: bytes):
     return True
 
 
-def get_mem(offset: int, size: int) -> bytes:
+def get_mem(offset: int, size: int) -> ctypes.Array[ctypes.c_char]:
     return (ctypes.c_char * size).from_address(offset)
 
 
@@ -198,7 +198,9 @@ def _get_memview_with_size(offset: int, size: int) -> Optional[memoryview]:
     )
 
 
-def map_struct(offset: int, type_: Type[Struct]) -> Struct:
+def map_struct(
+    offset: Union[int, ctypes.c_uint64, ctypes.c_uint32, ctypes._Pointer], type_: Type[Struct]
+) -> Struct:
     """Return an instance of the `type_` struct provided which shares memory
     with the provided offset.
     Note that the amount of memory to read is automatically determined by the

--- a/pymhf/main.py
+++ b/pymhf/main.py
@@ -365,6 +365,13 @@ def _run_module(
                 # which is one path deeper than we want to inject into the path.
                 if (mp := op.dirname(module_path)) not in _path:
                     _path.insert(0, mp)
+                # Also add the mod directory to the path.
+                # This will need more work and maybe we offset the path changing to the place where we load
+                # the mods, but this will help for now...
+                mod_folder = config.get("mod_dir")
+                mod_folder = canonicalize_setting(mod_folder, "pymhf", _module_path, binary_dir)
+                if mod_folder and mod_folder not in _path:
+                    _path.insert(0, mod_folder)
 
             saved_path = [x.replace("\\", "\\\\") for x in _path]
             pm_binary.inject_python_shellcode(

--- a/pymhf/utils/partial_struct.py
+++ b/pymhf/utils/partial_struct.py
@@ -81,13 +81,13 @@ def partial_struct(cls: _T) -> _T:
             raise ValueError(f"The field {field_name!r} has an invalid type: {field_type}")
         if field_offset is not None and not isinstance(field_offset, int):
             raise ValueError(f"The field {field_name!r} has an invalid offset: {field_offset!r}")
-        # COrrect the field offset by the size of the subclass.
+        # Correct the field offset by the size of the subclass.
         if field_offset and field_offset - subclass_size > curr_position:
             padding_bytes = field_offset - subclass_size - curr_position
             _fields_.append((f"_padding_{curr_position:X}", ctypes.c_ubyte * padding_bytes))
             curr_position += padding_bytes
         field_alignment = ctypes.alignment(field_type)
-        if curr_position % field_alignment != 0:
+        if field_alignment and (curr_position % field_alignment != 0):
             # If the field is not aligned to the correct position, then move the current position forward
             # to ensure it's right.
             # Don't bother adding this as padding since it will just add extra unnecessary fields.


### PR DESCRIPTION
I found while testing Newton that for some reason some pointer types are using the origin one somehow? Not sure what was happening but this makes it more reliable.
Also added the specified mod folder to the path. This isn't a final solution as there will still be import issues when doing inter-mod stuff between different folders.. Will need more labbing on that anyway I think...