### PR TITLE
gh-26: Bulk enable mods and fix get_caller and start_exe bugs

### DIFF
--- a/docs/docs/change_log.rst
+++ b/docs/docs/change_log.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Current (0.1.16.dev)
+--------------------
+
+- Improved hooking performance by using the bulk enable mode in minhook. (`#26 <https://github.com/monkeyman192/pyMHF/issues/26>`_)
+- Fixed an issue running mods where attach to already existing processes.
+- Fixed an issue with getting the caller offset address.
+
 0.1.15 (16/07/2025)
 -------------------
 

--- a/examples/test_mod.py
+++ b/examples/test_mod.py
@@ -1,0 +1,30 @@
+# /// script
+# dependencies = ["pymhf[gui]>=0.1.15"]
+# 
+# [tool.pymhf]
+# exe = "C:/Windows/System32/notepad.exe"
+# start_paused = false
+# start_exe = false
+#
+# [tool.pymhf.gui]
+# always_on_top = false
+# 
+# [tool.pymhf.logging]
+# log_dir = "."
+# log_level = "info"
+# window_name_override = "pyMHF Test Mod"
+# ///
+from logging import getLogger
+
+from pymhf import Mod
+
+logger = getLogger("TestMod")
+
+
+class TestMod(Mod):
+    __author__ = "monkeyman192"
+    __description__ = "Test mod to check if pyMHF works"
+
+    def __init__(self):
+        super().__init__()
+        logger.info("Loaded Test mod!")

--- a/pymhf/main.py
+++ b/pymhf/main.py
@@ -249,7 +249,7 @@ def _run_module(
         print("Python injected")
         proc = None
 
-    if pm_binary is None or proc is None:
+    if pm_binary is None:
         # TODO: Raise better error messages/reason why it couldn't load.
         print("FATAL ERROR: Cannot start process!")
         return
@@ -533,7 +533,14 @@ pymhf.core._internal.CACHE_DIR = {cache_dir!r}
         finally:
             print("Forcibly shutting down process")
             time.sleep(1)
-            for _pid in {pm_binary.process_id, log_pid}:
+            # Only close the main process if we started it. Otherwise leave it.
+            if start_exe:
+                pid_set = {pm_binary.process_id, log_pid}
+            else:
+                pid_set = {
+                    log_pid,
+                }
+            for _pid in pid_set:
                 if _pid:
                     try:
                         os.kill(_pid, SIGTERM)

--- a/typings/cyminhook/__init__.pyi
+++ b/typings/cyminhook/__init__.pyi
@@ -1,0 +1,23 @@
+# Type stubs for cyminhook
+
+class MinHook:
+    def __init__(self, *, signature=None, target=None, detour=None):
+        ...
+
+    def close(self):
+        """Close the hook. Removing it."""
+
+    def enable(self):
+        """Enable the hook."""
+
+    def disable(self):
+        """Disable the hook."""
+
+def queue_enable(hook: MinHook) -> None:
+    """Queue to enable an already created hook."""
+
+def queue_disable(hook: MinHook) -> None:
+    """Queue to disable an already created hook."""
+
+def apply_queued() -> None:
+    """Apply all queued changes in one go."""


### PR DESCRIPTION
closes #26 

So turns out every time you enable a hook it freezes all threads. I assume because we have a python thread which also gets frozen and resumed it adds a lot of overhead.
Now the enable step is significantly faster.

Also fixed an issue with the `@get_caller` decorator and the `start_exe` config value